### PR TITLE
sources: remove FCOMP from GNUmakefile

### DIFF
--- a/source/GNUmakefile
+++ b/source/GNUmakefile
@@ -46,17 +46,13 @@ INTEGRATOR_DIR ?= BS
 ifeq ($(findstring titan, $(UNAMEN)), titan)
 	# OLCF Titan
 	COMP ?= Cray
-	FCOMP ?= Cray
 else ifeq ($(findstring h2o, $(UNAMEN)), h2o)
 	# NCSA Blue Waters
 	COMP ?= Cray
-	FCOMP ?= Cray
 else ifeq ($(findstring mira, $(UNAMEN)), mira)
 	COMP ?= IBM
-	FCOMP ?= IBM
 else
 	COMP ?= g++
-	FCOMP ?= gfortran
 endif
 
 # This sets the EOS directory in $(MICROPHYSICS_HOME)/eos


### PR DESCRIPTION
As of BoxLib commit 763d40d ("no longer need to specify FCOMP") we no
longer need to specify FCOMP, so remove it.